### PR TITLE
Refactoring to avoid duplicate IDs even when a process forks(For Redis version)

### DIFF
--- a/src/Choco/Domain/IdWorker/Redis/IdWorkerOnRedis.php
+++ b/src/Choco/Domain/IdWorker/Redis/IdWorkerOnRedis.php
@@ -2,10 +2,10 @@
 
 namespace Adachi\Choco\Domain\IdWorker\Redis;
 
+use Adachi\Choco\Domain\IdConfig\IdConfig;
 use Adachi\Choco\Domain\IdValue\Element\RegionId;
 use Adachi\Choco\Domain\IdValue\Element\ServerId;
 use Adachi\Choco\Domain\IdValue\IdValue;
-use Adachi\Choco\Domain\IdConfig\IdConfig;
 use Adachi\Choco\Domain\IdWorker\AbstractIdWorker;
 use Adachi\Choco\Domain\IdWorker\IdWorkerInterface;
 use Predis\Client;
@@ -28,7 +28,7 @@ class IdWorkerOnRedis extends AbstractIdWorker implements IdWorkerInterface
      */
     private $redis;
 
-    const REDIS_SEQUENCE_KEY = 'chocolate_counter';
+    const REDIS_SEQUENCE_PREFIX_KEY = 'chocolate_counter_';
 
     /**
      * @param IdConfig $config
@@ -37,13 +37,13 @@ class IdWorkerOnRedis extends AbstractIdWorker implements IdWorkerInterface
      * @param array $credential
      */
     public function __construct(IdConfig $config,
-                                RegionId $regionId,
-                                ServerId $serverId,
-                                $credential = [
-                                    'scheme'   => 'tcp',
-                                    'host'     => '127.0.0.1',
-                                    'port'     => 6379
-                                ]
+        RegionId $regionId,
+        ServerId $serverId,
+        $credential = [
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379
+        ]
     ) {
         $this->config = $config;
         $this->regionId = $regionId;
@@ -58,26 +58,22 @@ class IdWorkerOnRedis extends AbstractIdWorker implements IdWorkerInterface
      */
     public function generate()
     {
+        $script = <<<LUA
+if redis.call('exists', KEYS[1]) == 1 then
+    return redis.call('incr', KEYS[1])
+else
+    redis.call('set', KEYS[1], 0, 'PX', 1000)
+    return 0
+end
+LUA;
+
         $timestamp = $this->generateTimestamp();
+        $sequence = $this->redis->eval($script, 1, self::REDIS_SEQUENCE_PREFIX_KEY . $timestamp);
 
-        $sequence = 0;
-
-        if (! is_null($this->lastTimestamp) && $timestamp->equals($this->lastTimestamp)) {
-            // Get
-            $sequence = $this->redis->incr(self::REDIS_SEQUENCE_KEY) & $this->config->getSequenceMask();
-
-            if ($sequence === 0) {
-                usleep(1000);
-                $timestamp = $this->generateTimestamp();
-            }
-        } else {
-            // Reset sequence if timestamp is different from last one.
-            $sequence = 0;
-            $this->redis->set(self::REDIS_SEQUENCE_KEY, $sequence);
+        if ($sequence !== ($sequence & $this->config->getSequenceMask())) {
+            // Sequence overflowed, rerun
+            return $this->generate();
         }
-
-        // Update lastTimestamp
-        $this->lastTimestamp = $timestamp;
 
         return new IdValue($timestamp, $this->regionId, $this->serverId, $sequence, $this->calculate($timestamp, $this->regionId, $this->serverId, $sequence));
     }

--- a/tests/Tests/IdGen/Domain/IdWorker/IdWorkerOnRedisTest.php
+++ b/tests/Tests/IdGen/Domain/IdWorker/IdWorkerOnRedisTest.php
@@ -4,7 +4,7 @@ use Adachi\Choco\Domain\IdValue\Element\RegionId;
 use Adachi\Choco\Domain\IdValue\Element\ServerId;
 use Adachi\Choco\Domain\IdValue\Element\Timestamp;
 use Adachi\Choco\Domain\IdConfig\IdConfig;
-
+use Adachi\Choco\Domain\IdWorker\Redis\IdWorkerOnRedis;
 
 /**
  * Class IdWorkerOnRedisTest
@@ -49,5 +49,115 @@ class IdWorkerOnRedisTest extends PHPUnit_Framework_TestCase
         $id = $this->idWorker->generate();
         $intValue = $this->idWorker->write($id);
         $this->assertEquals($id, $this->idWorker->read($intValue));
+    }
+
+    /**
+     * @test
+     */
+    public function createIdValueWithoutDuplication()
+    {
+        $config = new IdConfig(41, 5, 5, 4, 1414334507356);
+        $credential = [
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379
+        ];
+        $this->idWorker = new IdWorkerOnRedis($config, new RegionId(1), new ServerId(1), $credential);
+        /** @var int $ids */
+        $ids = array();
+        $expectedCount = 1000;
+
+        for ($i = 0; $i < $expectedCount; $i++) {
+            $ids[] = $this->idWorker->generate()->toInt();
+        }
+
+        // unique ids
+        $actual = array_values(array_unique($ids));
+
+        $message = "";
+        foreach (array_filter(array_count_values($ids), function ($v) { return --$v; }) as $id => $count) {
+            $idValue = $this->idWorker->read($id);
+            $message .= "value:{$idValue->asString()}, timestamp: {$idValue->timestamp}, sequence: {$idValue->sequence}, times: {$count}\n";
+        }
+
+        $this->assertCount($expectedCount, $actual, "The duplicate ID is as follows:\n{$message}");
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function createIdValueWithoutDuplicationUnderProcessForks()
+    {
+        $config = new IdConfig(41, 5, 5, 4, 1414334507356);
+        $credential = [
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379
+        ];
+        $this->idWorker = new IdWorkerOnRedis($config, new RegionId(1), new ServerId(1), $credential);
+
+        $pids = array();
+        $loopCount = 100;
+        $forkCount = 10;
+
+        // Prefix the temporary file for the result output
+        $sharedFilePrefix = tempnam('/var/tmp', get_class($this));
+
+        for ($i = 0; $i < $forkCount; $i++) {
+            // process fork
+            $pid = pcntl_fork();
+            if ($pid == -1) {
+                $this->fail('Failed to fork the process.');
+                break;
+            } else {
+                if ($pid) {
+                    // For the parent process
+                    $pids[] = $pid;
+                } else {
+                    // For child processes
+                    $sharedFile = $sharedFilePrefix . getmypid();
+                    $ids = array();
+                    for ($j = 0; $j < $loopCount; $j++) {
+                        $ids[] = $this->idWorker->generate()->toInt();
+                    }
+                    // Output the result to a temporary file
+                    file_put_contents($sharedFile, serialize($ids));
+
+                    // Terminate child process
+                    exit;
+                }
+            }
+        }
+        // Waiting for the process to exit
+        $idsArray = array();
+        foreach ($pids as $pid) {
+            pcntl_waitpid($pid, $status);
+
+            // Get the result output of each process.
+            $sharedFile = $sharedFilePrefix . $pid;
+            $idsArray[] = unserialize(file_get_contents($sharedFile));
+
+            // Delete temporary files
+            unlink($sharedFile);
+        }
+
+        // flatten ids
+        $ids = array();
+        array_walk_recursive($idsArray, function($e) use (&$ids) { $ids[] = $e; });
+
+        // unique ids
+        $actual = array_values(array_unique($ids));
+
+        $message = "";
+        foreach (array_filter(array_count_values($ids), function ($v) { return --$v; }) as $id => $count) {
+            $idValue = $this->idWorker->read($id);
+            $message .= "value:{$idValue->asString()}, timestamp: {$idValue->timestamp}, sequence: {$idValue->sequence}, times: {$count}\n";
+        }
+
+        $this->assertCount($loopCount * $forkCount,
+            $actual,
+            "The duplicate ID is as follows:\n{$message}");
     }
 }


### PR DESCRIPTION
# Problem
Duplicate process fork to get ID.

```
1) IdWorkerOnRedisTest::createIdValueWithoutDuplicationUnderProcessForks
The duplicate ID is as follows:
value:3484841494675984, timestamp: 212697845134, sequence: 0, times: 2
value:3484841494725136, timestamp: 212697845137, sequence: 0, times: 2
value:3484841495183888, timestamp: 212697845165, sequence: 0, times: 3
value:3484841495233040, timestamp: 212697845168, sequence: 0, times: 4

.. snip ..

value:3484841499460112, timestamp: 212697845426, sequence: 0, times: 2
value:3484841499623952, timestamp: 212697845436, sequence: 0, times: 2

Failed asserting that actual size 466 matches expected size 1000.
```

# Changes

* Changed Redis operations to atomic processing with Lua scripts.  
Sequences are now counted correctly even when running in multiple processes.  
* Adjust sleep processing when a sequence overflows digits.