### PR TITLE
Refactoring to avoid duplicate IDs even when a process forks.

### DIFF
--- a/src/Choco/Domain/IdWorker/SharedMemory/IdWorkerOnSharedMemory.php
+++ b/src/Choco/Domain/IdWorker/SharedMemory/IdWorkerOnSharedMemory.php
@@ -23,29 +23,38 @@ class IdWorkerOnSharedMemory extends AbstractIdWorker implements IdWorkerInterfa
     private $semaphoreId;
 
     /**
+     * @var int
+     */
+    private $memorySize;
+
+    /**
      * Key name of shared memory block
      * @fixme refactor
      */
     const SHM_KEY = 12345;
 
     /**
-     * Key name of shared memory segment
-     * @fixme refactor
+     * Number of processes accessing shared memory
      */
-    const SHM_SEQUENCE = 54321;
+    const PROCESS_COUNT = 30;
 
     /**
      * @param IdConfig $config
      * @param RegionId $regionId
      * @param ServerId $serverId
-     * @param int $semaphoreId
+     * @param int|null $semaphoreId
      */
-    public function __construct(IdConfig $config, RegionId $regionId, ServerId $serverId, $semaphoreId = 45454)
+    public function __construct(IdConfig $config, RegionId $regionId, ServerId $serverId, $semaphoreId = null)
     {
         $this->config = $config;
         $this->regionId = $regionId;
         $this->serverId = $serverId;
-        $this->semaphoreId = $semaphoreId;
+        if ($semaphoreId) {
+            $this->semaphoreId = $semaphoreId;
+        } else {
+            $this->semaphoreId = ftok(__FILE__, chr(4));
+        }
+        $this->memorySize = $this->calculateMemorySize($config);
     }
 
     /**
@@ -53,43 +62,118 @@ class IdWorkerOnSharedMemory extends AbstractIdWorker implements IdWorkerInterfa
      */
     public function generate()
     {
-        $timestamp = $this->generateTimestamp();
-
         // Acquire semaphore
         $semaphore = sem_get($this->semaphoreId);
         sem_acquire($semaphore);
 
         // Attach shared memory
-        $memory = shm_attach(self::SHM_KEY);
+        $memory = shm_attach(self::SHM_KEY, $this->memorySize);
 
         $sequence = 0;
 
-        if (! is_null($this->lastTimestamp) && $timestamp->equals($this->lastTimestamp)) {
-            // Get
-            $sequence = (shm_get_var($memory, self::SHM_SEQUENCE) + 1) & $this->config->getSequenceMask();
+        $timestamp = $this->generateTimestamp();
 
-            // Increment sequence
-            shm_put_var($memory, self::SHM_SEQUENCE, $sequence);
+        // Handle warnings when there is not enough shared memory left.
+        $errorReportingLevel = \error_reporting(\E_WARNING);
 
-            if ($sequence === 0) {
-                usleep(1000);
-                $timestamp = $this->generateTimestamp();
+        \set_error_handler(
+            /**
+             * @param int $severity
+             * @param string $message
+             * @param string $file
+             * @param int $line
+             */
+            function ($severity, $message, $file, $line) {
+                // Clear all data in shared memory.
+                $this->clear();
+                throw new \RuntimeException($message);
             }
-        } else {
-            // Reset sequence if timestamp is different from last one.
-            $sequence = 0;
-            shm_put_var($memory, self::SHM_SEQUENCE, $sequence);
+        );
+
+        try {
+            if (shm_has_var($memory, $timestamp->getValue())) {
+                // Get
+                $sequence = (shm_get_var($memory, $timestamp->getValue()) + 1) & $this->config->getSequenceMask();
+
+                if ($sequence > 0) {
+                    // Increment sequence
+                    shm_put_var($memory, $timestamp->getValue(), $sequence);
+                } else {
+                    // Sequence overflowed, rerun
+                    usleep(1);
+                    shm_detach($memory);
+                    sem_release($semaphore);
+                    return $this->generate();
+                }
+            } else {
+                $sequence = 0;
+                // Reset sequence if timestamp is different from last one.
+                shm_put_var($memory, $timestamp->getValue(), $sequence);
+            }
+        } finally {
+            \restore_error_handler();
+            \error_reporting($errorReportingLevel);
         }
 
-        // Detach shared memory
+        try {
+            return new IdValue(
+                $timestamp,
+                $this->regionId,
+                $this->serverId,
+                $sequence,
+                $this->calculate($timestamp, $this->regionId, $this->serverId, $sequence)
+            );
+        } finally {
+            if ($this->lastTimestamp && !$timestamp->equals($this->lastTimestamp)) {
+                // Remove the previous shared memory variable.
+                if ($this->lastTimestamp && shm_has_var($memory, $this->lastTimestamp->getValue())) {
+                    @shm_remove_var($memory, $this->lastTimestamp->getValue());
+                }
+            }
+
+            // Detach shared memory
+            shm_detach($memory);
+
+            // Update lastTimestamp
+            $this->lastTimestamp = $timestamp;
+
+            // Release semaphore
+            sem_release($semaphore);
+        }
+    }
+
+    /**
+     * Clear all data in shared memory.
+     * Call this when shared memory is not freed for some reason and you get an `shm_put_var(): not enough shared memory left` (E_WARNING level) warning
+     */
+    public function clear()
+    {
+        $memory = shm_attach(self::SHM_KEY, $this->memorySize);
+        shm_remove($memory);
         shm_detach($memory);
+    }
 
-        // Release semaphore
-        sem_release($semaphore);
+    function __destruct()
+    {
+        // Release the last inserted shared memory.
+        $memory = shm_attach(self::SHM_KEY, $this->memorySize);
+        if ($this->lastTimestamp && shm_has_var($memory, $this->lastTimestamp->getValue())) {
+            @shm_remove_var($memory, $this->lastTimestamp->getValue());
+        }
+        shm_detach($memory);
+    }
 
-        // Update lastTimestamp
-        $this->lastTimestamp = $timestamp;
-
-        return new IdValue($timestamp, $this->regionId, $this->serverId, $sequence, $this->calculate($timestamp, $this->regionId, $this->serverId, $sequence));
+    /**
+     *　Calculates the size of the shared memory required to store the sequence.
+     *
+     * @param IdConfig $config
+     * @return int
+     */
+    private function calculateMemorySize(IdConfig $config)
+    {
+        $headerSize = (PHP_INT_SIZE * 4) + 8;
+        $sequenceSize = (((strlen(serialize($config->getMaxSequence())) + (4 * PHP_INT_SIZE)) / 4) * 4) + 4;
+        //　Store two variables in shared memory per process.
+        return $headerSize + $sequenceSize * self::PROCESS_COUNT * 2;
     }
 }

--- a/tests/Tests/IdGen/Domain/IdWorker/IdWorkerOnSharedMemoryTest.php
+++ b/tests/Tests/IdGen/Domain/IdWorker/IdWorkerOnSharedMemoryTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use Adachi\Choco\Domain\IdConfig\IdConfig;
 use Adachi\Choco\Domain\IdValue\Element\RegionId;
 use Adachi\Choco\Domain\IdValue\Element\ServerId;
 use Adachi\Choco\Domain\IdValue\Element\Timestamp;
-use Adachi\Choco\Domain\IdConfig\IdConfig;
+use Adachi\Choco\Domain\IdWorker\SharedMemory\IdWorkerOnSharedMemory;
 
 /**
  * Class IdWorkerOnSharedMemoryTest
@@ -43,5 +44,109 @@ class IdWorkerOnSharedMemoryTest extends PHPUnit_Framework_TestCase
         $id = $this->idWorker->generate();
         $intValue = $this->idWorker->write($id);
         $this->assertEquals($id, $this->idWorker->read($intValue));
+    }
+
+    /**
+     * @test
+     */
+    public function createIdValueWithoutDuplication()
+    {
+        $config = new IdConfig(41, 5, 5, 4, 1414334507356);
+        $this->idWorker = new IdWorkerOnSharedMemory($config, new RegionId(1), new ServerId(1), 45454);
+        // Clear all data in shared memory.
+        $this->idWorker->clear();
+        /** @var int $ids */
+        $ids = array();
+        $expectedCount = 1000;
+
+        for ($i = 0; $i < $expectedCount; $i++) {
+            $ids[] = $this->idWorker->generate()->toInt();
+        }
+
+        // unique ids
+        $actual = array_values(array_unique($ids));
+
+        $message = "";
+        foreach (array_filter(array_count_values($ids), function ($v) { return --$v; }) as $id => $count) {
+            $idValue = $this->idWorker->read($id);
+            $message .= "value:{$idValue->asString()}, timestamp: {$idValue->timestamp}, sequence: {$idValue->sequence}, times: {$count}\n";
+        }
+
+        $this->assertCount($expectedCount, $actual, "The duplicate ID is as follows:\n{$message}");
+    }
+
+    /**
+     * @test
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function createIdValueWithoutDuplicationUnderProcessForks()
+    {
+        $config = new IdConfig(41, 5, 5, 4, 1414334507356);
+        $this->idWorker = new IdWorkerOnSharedMemory($config, new RegionId(1), new ServerId(1), 45454);
+        // Clear all data in shared memory.
+        $this->idWorker->clear();
+
+        $pids = array();
+        $loopCount = 100;
+        $forkCount = 10;
+
+        // Prefix the temporary file for the result output
+        $sharedFilePrefix = tempnam('/var/tmp', get_class($this));
+
+        for ($i = 0; $i < $forkCount; $i++) {
+            // process fork
+            $pid = pcntl_fork();
+            if ($pid == -1) {
+                $this->fail('Failed to fork the process.');
+                break;
+            } else {
+                if ($pid) {
+                    // For the parent process
+                    $pids[] = $pid;
+                } else {
+                    // For child processes
+                    $sharedFile = $sharedFilePrefix . getmypid();
+                    $ids = array();
+                    for ($j = 0; $j < $loopCount; $j++) {
+                        $ids[] = $this->idWorker->generate()->toInt();
+                    }
+                    // Output the result to a temporary file
+                    file_put_contents($sharedFile, serialize($ids));
+
+                    // Terminate child process
+                    exit;
+                }
+            }
+        }
+        // Waiting for the process to exit
+        $idsArray = array();
+        foreach ($pids as $pid) {
+            pcntl_waitpid($pid, $status);
+
+            // Get the result output of each process.
+            $sharedFile = $sharedFilePrefix . $pid;
+            $idsArray[] = unserialize(file_get_contents($sharedFile));
+
+            // Delete temporary files
+            unlink($sharedFile);
+        }
+
+        // flatten ids
+        $ids = array();
+        array_walk_recursive($idsArray, function($e) use (&$ids) { $ids[] = $e; });
+
+        // unique ids
+        $actual = array_values(array_unique($ids));
+
+        $message = "";
+        foreach (array_filter(array_count_values($ids), function ($v) { return --$v; }) as $id => $count) {
+            $idValue = $this->idWorker->read($id);
+            $message .= "value:{$idValue->asString()}, timestamp: {$idValue->timestamp}, sequence: {$idValue->sequence}, times: {$count}\n";
+        }
+
+        $this->assertCount($loopCount * $forkCount,
+            $actual,
+            "The duplicate ID is as follows:\n{$message}");
     }
 }


### PR DESCRIPTION
## Problem
Duplicate process fork to get ID.

```
1) IdWorkerOnSharedMemoryTest::createIdValueWithoutDuplicationUnderProcessForks
Failed asserting that actual size 511 matches expected size 1000.
```

## Changes
* Changed the key for sequences to be stored in shared memory to a timestamp.
  Sequences are now counted correctly even when running in multiple processes.
* Specify memory size when creating a shared memory segment due to changes in shared memory usage.
* Deleting variables in shared memory when destroying an instance.
  In addition, make sure that all variables are deleted when shared memory is insufficient.
* Adjust sleep processing when a sequence overflows digits.
* Added dynamic ID generation when the semaphore ID is not specified and the instance is created.

